### PR TITLE
php-fpm binary is php-fpm5 so added symlink

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ RUN apk update \
     && runit-enable-service php-fpm \
     && chown nginx:nginx ${DOCKAGE_WEBROOT_DIR} \
     && mv ${DOCKAGE_ETC_DIR}/sbin/* /sbin \
-    && rm -rf /var/cache/apk/* ${DOCKAGE_ETC_DIR}/sbin ${DOCKAGE_WEBROOT_DIR}/*
+    && rm -rf /var/cache/apk/* ${DOCKAGE_ETC_DIR}/sbin ${DOCKAGE_WEBROOT_DIR}/* \
+    && ln -s /usr/bin/php-fpm5 /usr/bin/php-fpm
 
 EXPOSE 80/tcp 443/tcp
 


### PR DESCRIPTION
Kept getting 
`php-fpm has not installed.`
Looks like php-fpm5 installs as /usr/bin/php-fpm5 rather than /usr/bin/php-fpm